### PR TITLE
Register entry types

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,11 @@
   </section>
   <section>
     <h2>Processing</h2>
+    <p>A user agent implementing the User Timing API must perform the following steps:</p>
+    <ol>
+      <li>Run the <a data-cite="!PERFORMANCE-TIMELINE-2#dfn-register-a-performance-entry-type">register a performance entry type</a> algorithm with <code>"mark"</code> as input.</li>
+      <li>Run the <a data-cite="!PERFORMANCE-TIMELINE-2#dfn-register-a-performance-entry-type">register a performance entry type</a> algorithm with <code>"measure"</code> as input.</li>
+    </ol>
     <section>
       <h2>Convert a <var>name</var> to a <var>timestamp</var></h2>
       <p>To <dfn>convert a name to a <a data-cite="!HR-TIME-2#idl-def-domhighrestimestamp">timestamp</a></dfn> given a <var>name</var> that is a <a data-cite="!WEBIDL#dfn-read-only">read only attribute</a> in the <code><a data-cite="!NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface, run these steps:<p>


### PR DESCRIPTION
This change adds the calls to register entryTypes "mark" and "measure".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/user-timing/pull/45.html" title="Last updated on Nov 30, 2018, 4:14 PM GMT (ef536c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/45/fc644a0...npm1:ef536c5.html" title="Last updated on Nov 30, 2018, 4:14 PM GMT (ef536c5)">Diff</a>