### PR TITLE
Sanity check for timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,13 @@
           <li>
             Set <var>entry</var>'s <code>startTime</code> attribute as follows:
             <ol>
-              <li>If <var>markOptions</var> is present and its <a>startTime</a> member is present, then set it to the value of <var>markOptions</var>'s <a>startTime</a>.</li>
+              <li>
+                If <var>markOptions</var> is present and its <a>startTime</a> member is present, then:
+                <ol>
+                  <li>If <var>markOptions</var>'s <a>startTime</a> is negative, throw a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+                  <li>Otherwise, set <var>entry</var>'s <code>startTime</code> to the value of <var>markOptions</var>'s <a>startTime</a>.</li>
+                </ol>
+              </li>
               <li>Otherwise, set it to the value that would be returned by the <code>Performance</code> object's <a data-cite="HR-TIME-2#dom-performance-now"><code>now()</code></a> method.</li>
             </ol>
           </li>
@@ -357,7 +363,13 @@
         <ol>
           <li>If <var>mark</var> is a <code>DOMString</code> and it has the same name as a <a data-cite="WEBIDL#dfn-read-only">read only attribute</a> in the <code><a data-cite="NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface, let <var>end time</var> be the value returned by running the <a>convert a name to a timestamp</a> algorithm with <var>name</var> set to the value of <var>mark</var>.</li>
           <li>Otherwise, if <var>mark</var> is a <code>DOMString</code>, let <var>end time</var> be the value of the <code>startTime</code> attribute from the most recent occurrence of a <a>PerformanceMark</a> object in the <a data-cite="PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer">performance entry buffer</a> whose <code>name</code> matches the value of <var>mark</var>. If no matching entry is found, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
-          <li>Otherwise, if <var>mark</var> is a <code>DOMHighResTimeStamp</code>, let <var>end time</var> be <var>mark</var>.</li>
+          <li>
+            Otherwise, if <var>mark</var> is a <code>DOMHighResTimeStamp</code>:
+            <ol>
+              <li>If <var>mar</var> is negative, throw a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+              <li>Otherwise, let <var>end time</var> be <var>mark</var>.</li>
+            </ol>
+          </li>
         </ol>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
           <li>
             Otherwise, if <var>mark</var> is a <code>DOMHighResTimeStamp</code>:
             <ol>
-              <li>If <var>mar</var> is negative, throw a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+              <li>If <var>mark</var> is negative, throw a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
               <li>Otherwise, let <var>end time</var> be <var>mark</var>.</li>
             </ol>
           </li>


### PR DESCRIPTION
This PR adds a sanity check: timestamps used in mark and measure must not be negative.

Thoughts on using SyntaxError? Maybe NotSupportedError would be better? Options are here https://heycam.github.io/webidl/#idl-DOMException-error-names


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/50.html" title="Last updated on Feb 1, 2019, 7:12 PM UTC (76e64e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/50/f57e4d4...76e64e7.html" title="Last updated on Feb 1, 2019, 7:12 PM UTC (76e64e7)">Diff</a>