### PR TITLE
L3 fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,12 +153,12 @@
       <p>The <a>Performance</a> interface is defined in [[!HR-TIME-2]].</p>
       <pre class="idl">
         dictionary PerformanceMarkOptions {
-            any detail = null;
+            any detail;
             DOMHighResTimeStamp startTime;
         };
 
         dictionary PerformanceMeasureOptions {
-            any detail = null;
+            any detail;
             (DOMString or DOMHighResTimeStamp) start;
             DOMHighResTimeStamp duration;
             (DOMString or DOMHighResTimeStamp) end;
@@ -167,7 +167,7 @@
         partial interface Performance {
             PerformanceMark mark(DOMString markName, optional PerformanceMarkOptions markOptions);
             void clearMarks(optional DOMString markName);
-            PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions)? startOrMeasureOptions, optional DOMString endMark);
+            PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions, optional DOMString endMark);
             void clearMeasures(optional DOMString measureName);
         };
       </pre>
@@ -204,16 +204,20 @@
         <h2><dfn>measure()</dfn> method</h2>
         <p>Stores the <code>DOMHighResTimeStamp</code> duration between two marks along with the associated name (a "measure"). It MUST run these steps:</p>
         <ol>
-          <li>If <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, and if <var>endMark</var> is present, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li> 
-          <li>If <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> and <a>end</a> members are both omitted, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>  
-          <li>If <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a>, <a>duration</a>, and <a>end</a> members are all present, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+          <li>If <var>startOrMeasureOptions</var> is a non-<a data-cite="INFRA#map-is-empty">empty</a> <a>PerformanceMeasureOptions</a> object, run the following checks:
+            <ol>
+              <li>If <var>endMark</var> is given, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li> 
+              <li>If <var>startOrMeasureOptions</var>'s <a>start</a> and <a>end</a> members are both omitted, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>  
+              <li>If <var>startOrMeasureOptions</var>'s <a>start</a>, <a>duration</a>, and <a>end</a> members are all present, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
+            </ol>
+          </li>
           <li>
             Compute <var>end time</var> as follows:
             <ol>
-              <li>If <var>endMark</var> is present, let <var>end time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>endMark</var>.</li>
-              <li>Otherwise, if <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, and if its <a>end</a> member is present, let <var>end time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>end</a>.</li> 
+              <li>If <var>endMark</var> is given, let <var>end time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>endMark</var>.</li>
+              <li>Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>end</a> member is present, let <var>end time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>end</a>.</li> 
               <li>
-                Otherwise, if <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> and <a>duration</a> members are both present:
+                Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> and <a>duration</a> members are both present:
                 <ol>
                   <li>Let <var>start</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>start</a>.</li>
                   <li>Let <var>duration</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>duration</a>.</li>
@@ -226,16 +230,16 @@
           <li>
             Compute <var>start time</var> as follows:
             <ol>
-              <li>If <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> member is present, let <var>start time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>start</a>.</li>
+              <li>If <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> member is present, let <var>start time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>start</a>.</li>
               <li>
-                Otherwise, if <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, and if its <a>duration</a> and <a>end</a> members are both present:
+                Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>duration</a> and <a>end</a> members are both present:
                 <ol>
                   <li>Let <var>duration</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>duration</a>.</li>
                   <li>Let <var>end</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>end</a>.</li>
                   <li>Let <var>start time</var> be <var>end</var> minus <var>duration</var>.</li>
                 </ol>
               </li>
-              <li>Otherwise, if <var>startOrMeasureOptions</var> is present and is a <code>DOMString</code>, let <var>start time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>.</li>
+              <li>Otherwise, if <var>startOrMeasureOptions</var> is a <code>DOMString</code>, let <var>start time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>.</li>
               <li>Otherwise, let <var>start time</var> be <code>0</code>.</li>
             </ol>
           </li>
@@ -247,7 +251,7 @@
           <li>
             Set <var>entry</var>'s <code>detail</code> attribute as follows:  
             <ol>  
-              <li>If <var>startOrMeasureOptions</var> is present and is a <a>PerformanceMeasureOptions</a> object, set it to the result of calling the <a data-cite="HTML/infrastructure.html#structuredserialize">StructuredSerialize</a> algorithm on <var>startOrMeasureOptions</var>'s <a>detail</a>.</li> 
+              <li>If <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, set it to the result of calling the <a data-cite="HTML/infrastructure.html#structuredserialize">StructuredSerialize</a> algorithm on <var>startOrMeasureOptions</var>'s <a>detail</a>.</li> 
               <li>Otherwise, set it to <code>null</code>.</li>  
             </ol> 
           </li> 
@@ -310,9 +314,9 @@
             Set <var>entry</var>'s <code>startTime</code> attribute as follows:
             <ol>
               <li>
-                If <var>markOptions</var> is present and its <a>startTime</a> member is present, then:
+                If <var>markOptions</var>'s <a>startTime</a> member is present, then:
                 <ol>
-                  <li>If <var>markOptions</var>'s <a>startTime</a> is negative, throw a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+                  <li>If <var>markOptions</var>'s <a>startTime</a> is negative, throw a <a data-cite="WEBIDL#exceptiondef-rangeerror"><code>RangeError</code></a>.</li>
                   <li>Otherwise, set <var>entry</var>'s <code>startTime</code> to the value of <var>markOptions</var>'s <a>startTime</a>.</li>
                 </ol>
               </li>
@@ -320,13 +324,7 @@
             </ol>
           </li>
           <li>Set <var>entry</var>'s <code>duration</code> attribute to <code>0</code>.</li>
-          <li>
-            Set <var>entry</var>'s <code>detail</code> attribute as follows:
-            <ol>
-              <li>If <var>markOptions</var> is present, set it to the result of calling the <a data-cite="HTML/infrastructure.html#structuredserialize">StructuredSerialize</a> algorithm on <var>markOptions</var>'s <a>detail</a>.</li>
-              <li>Otherwise, set it to <code>null</code>.</li>
-            </ol>
-          </li>
+          <li>Set <var>entry</var>'s <code>detail</code> attribute to the result of calling the <a data-cite="HTML/infrastructure.html#structuredserialize">StructuredSerialize</a> algorithm on <var>markOptions</var>'s <a>detail</a>.</li>
         </ol>
       </section>
     </section>
@@ -364,7 +362,7 @@
           <li>
             Otherwise, if <var>mark</var> is a <code>DOMHighResTimeStamp</code>:
             <ol>
-              <li>If <var>mark</var> is negative, throw a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+              <li>If <var>mark</var> is negative, throw a <a data-cite="WEBIDL#exceptiondef-rangeerror"><code>RangeError</code></a>.</li>
               <li>Otherwise, let <var>end time</var> be <var>mark</var>.</li>
             </ol>
           </li>
@@ -374,7 +372,7 @@
       <h2>Convert a <var>name</var> to a <var>timestamp</var></h2>
       <p>To <dfn>convert a name to a <a data-cite="HR-TIME-2#idl-def-domhighrestimestamp">timestamp</a></dfn> given a <var>name</var> that is a <a data-cite="WEBIDL#dfn-read-only">read only attribute</a> in the <code><a data-cite="NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface, run these steps:<p>
       <ol>
-        <li>If the <a data-cite="HTML/webappapis.html#global-object">global object</a> is not a <code>Window</code> object, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+        <li>If the <a data-cite="HTML/webappapis.html#global-object">global object</a> is not a <code>Window</code> object, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
         <li>If <var>name</var> is <code>navigationStart</code>, return <code>0</code>.</li>
         <li>Let <var>startTime</var> be the value of <code>navigationStart</code> in the <code><a data-cite="NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface.</li>
         <li>Let <var>endTime</var> be the value of <var>name</var> in the <code><a data-cite="NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface.</li>

--- a/index.html
+++ b/index.html
@@ -208,16 +208,16 @@
             <ol>
               <li>If <var>endMark</var> is given, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li> 
               <li>If <var>startOrMeasureOptions</var>'s <a>start</a> and <a>end</a> members are both omitted, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>  
-              <li>If <var>startOrMeasureOptions</var>'s <a>start</a>, <a>duration</a>, and <a>end</a> members are all present, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
+              <li>If <var>startOrMeasureOptions</var>'s <a>start</a>, <a>duration</a>, and <a>end</a> members are all <a data-cite="WEBIDL#dfn-present">present</a>, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
             </ol>
           </li>
           <li>
             Compute <var>end time</var> as follows:
             <ol>
               <li>If <var>endMark</var> is given, let <var>end time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>endMark</var>.</li>
-              <li>Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>end</a> member is present, let <var>end time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>end</a>.</li> 
+              <li>Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>end</a> member is <a data-cite="WEBIDL#dfn-present">present</a>, let <var>end time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>end</a>.</li> 
               <li>
-                Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> and <a>duration</a> members are both present:
+                Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> and <a>duration</a> members are both <a data-cite="WEBIDL#dfn-present">present</a>:
                 <ol>
                   <li>Let <var>start</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>start</a>.</li>
                   <li>Let <var>duration</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>duration</a>.</li>
@@ -230,9 +230,9 @@
           <li>
             Compute <var>start time</var> as follows:
             <ol>
-              <li>If <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> member is present, let <var>start time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>start</a>.</li>
+              <li>If <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>start</a> member is <a data-cite="WEBIDL#dfn-present">present</a>, let <var>start time</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <var>startOrMeasureOptions</var>'s <a>start</a>.</li>
               <li>
-                Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>duration</a> and <a>end</a> members are both present:
+                Otherwise, if <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, and if its <a>duration</a> and <a>end</a> members are both <a data-cite="WEBIDL#dfn-present">present</a>:
                 <ol>
                   <li>Let <var>duration</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>duration</a>.</li>
                   <li>Let <var>end</var> be the value returned by running the <a>convert a mark to a timestamp</a> algorithm passing in <a>end</a>.</li>
@@ -314,7 +314,7 @@
             Set <var>entry</var>'s <code>startTime</code> attribute as follows:
             <ol>
               <li>
-                If <var>markOptions</var>'s <a>startTime</a> member is present, then:
+                If <var>markOptions</var>'s <a>startTime</a> member is <a data-cite="WEBIDL#dfn-present">present</a>, then:
                 <ol>
                   <li>If <var>markOptions</var>'s <a>startTime</a> is negative, throw a <a data-cite="WEBIDL#exceptiondef-rangeerror"><code>RangeError</code></a>.</li>
                   <li>Otherwise, set <var>entry</var>'s <code>startTime</code> to the value of <var>markOptions</var>'s <a>startTime</a>.</li>


### PR DESCRIPTION
This PR does the following:
* Remove "= null" from the detail fields, fixing https://github.com/w3c/user-timing/issues/56.
* Replace the SyntaxErrors introduced in L3 with either RangeErrors or TypeErrors, fixing https://github.com/w3c/user-timing/issues/55.
* Make startOrOptions not nullable again, fixing https://github.com/w3c/user-timing/issues/54. The optional dictionaries (or union including dictionary) have an empty dictionary as its default value. Thus, the logic in measure() is changed accordingly because when an optional dictionary is not given, it will be defaulted to the empty dictionary.
* Replace some of the "is present" with "is given" because that is more accurate terminology for optional arguments.

@maxlgu FYI