### PR TITLE
Replace RangeErrors with TypeErrors

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
               <li>
                 If <var>markOptions</var>'s <a>startTime</a> member is <a data-cite="WEBIDL#dfn-present">present</a>, then:
                 <ol>
-                  <li>If <var>markOptions</var>'s <a>startTime</a> is negative, throw a <a data-cite="WEBIDL#exceptiondef-rangeerror"><code>RangeError</code></a>.</li>
+                  <li>If <var>markOptions</var>'s <a>startTime</a> is negative, throw a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
                   <li>Otherwise, set <var>entry</var>'s <code>startTime</code> to the value of <var>markOptions</var>'s <a>startTime</a>.</li>
                 </ol>
               </li>
@@ -362,7 +362,7 @@
           <li>
             Otherwise, if <var>mark</var> is a <code>DOMHighResTimeStamp</code>:
             <ol>
-              <li>If <var>mark</var> is negative, throw a <a data-cite="WEBIDL#exceptiondef-rangeerror"><code>RangeError</code></a>.</li>
+              <li>If <var>mark</var> is negative, throw a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
               <li>Otherwise, let <var>end time</var> be <var>mark</var>.</li>
             </ol>
           </li>


### PR DESCRIPTION
Per feedback from @bzbarsky, it seems TypeErrors should be used even for negative checks.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/58.html" title="Last updated on Apr 25, 2019, 3:42 PM UTC (1cd6630)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/58/4ded0fb...1cd6630.html" title="Last updated on Apr 25, 2019, 3:42 PM UTC (1cd6630)">Diff</a>