### PR TITLE
Giving startOrOptions a default value for IDL conformance.

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
         partial interface Performance {
             PerformanceMark mark(DOMString markName, optional PerformanceMarkOptions markOptions);
             void clearMarks(optional DOMString markName);
-			PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions = {}, optional DOMString endMark);
+            PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions = {}, optional DOMString endMark);
             void clearMeasures(optional DOMString measureName);
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
         partial interface Performance {
             PerformanceMark mark(DOMString markName, optional PerformanceMarkOptions markOptions);
             void clearMarks(optional DOMString markName);
-            PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions, optional DOMString endMark);
+			PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions = {}, optional DOMString endMark);
             void clearMeasures(optional DOMString measureName);
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
         };
 
         partial interface Performance {
-            PerformanceMark mark(DOMString markName, optional PerformanceMarkOptions markOptions);
+            PerformanceMark mark(DOMString markName, optional PerformanceMarkOptions markOptions = {});
             void clearMarks(optional DOMString markName);
             PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions = {}, optional DOMString endMark);
             void clearMeasures(optional DOMString measureName);


### PR DESCRIPTION
According to the Web IDL spec, section 2.5.3 (some formatting is mine):

If
- the type of an argument is a dictionary type or a union type that has
a dictionary type as one of its flattened member types,
- and that dictionary type and its ancestors have no required members,
- and the argument is either the final argument or is followed only by
optional arguments,

then the argument must be specified as optional and have a default value
provided.

IIUC, the 'startOrOptions' parameter for Performance.Measure falls into
the category where it needs to be marked optional and given a default
value. Right now it is marked optional but does not have a default
value.

This change adds a default value of an empty dictionary for the
startOrOptions parameter. This should not change any user-visible
behaviour because an omitted paremeter would have been treated as an
empty dictionary in the bindings layer anyways.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tommckee1/user-timing/pull/65.html" title="Last updated on Jul 16, 2019, 6:32 PM UTC (6032621)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/65/778a7e5...tommckee1:6032621.html" title="Last updated on Jul 16, 2019, 6:32 PM UTC (6032621)">Diff</a>