### PR TITLE
Giving markOptions a default value for IDL conformance.

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
       <p>The <a>PerformanceMark</a> interface also exposes marks created via the <a>performance.mark</a> method to the <a data-cite="PERFORMANCE-TIMELINE-2#dfn-performance-timeline">Performance Timeline</a>.</p>
       <pre class="idl">
         [Exposed=(Window,Worker),
-         Constructor(DOMString markName, optional PerformanceMarkOptions markOptions)]
+         Constructor(DOMString markName, optional PerformanceMarkOptions markOptions = {})]
         interface PerformanceMark : PerformanceEntry {
           readonly attribute any detail;
         };


### PR DESCRIPTION
Similar to https://github.com/w3c/user-timing/pull/65 but the
'markOptions' argument to the PerformanceMark constructor needs a
default value too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tommckee1/user-timing/pull/66.html" title="Last updated on Jul 17, 2019, 3:49 PM UTC (2346897)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/66/6198dcf...tommckee1:2346897.html" title="Last updated on Jul 17, 2019, 3:49 PM UTC (2346897)">Diff</a>