### PR TITLE
Pass realms in UserTiming constructors

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
               <li>Otherwise, let <var>start time</var> be <code>0</code>.</li>
             </ol>
           </li>
-          <li>Create a new <a>PerformanceMeasure</a> object (<var>entry</var>).</li>
+          <li>Create a new <a>PerformanceMeasure</a> object (<var>entry</var>) with the <a data-cite="ECMA-262#current-realm">current realm</a>.</li>
           <li>Set <var>entry</var>'s <code>name</code> attribute to <var>measureName</var>.</li>
           <li>Set <var>entry</var>'s <code>entryType</code> attribute to <code>DOMString "measure"</code>.</li>
           <li>Set <var>entry</var>'s <code>startTime</code> attribute to <var>start time</var>.</li>
@@ -314,8 +314,8 @@
         <h3>The <dfn><a>PerformanceMark</a> Constructor</dfn></h3>
         <p>The <a>PerformanceMark constructor</a> must run the following steps:</p>
         <ol>
-          <li>If the <a data-cite="HTML/webappapis.html#global-object">global object</a> is a <code>Window</code> object and <var>markName</var> uses the same name as a <a data-cite="WEBIDL#dfn-read-only">read only attribute</a> in the <code><a data-cite="NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
-          <li>Create a new <a>PerformanceMark</a> object (<var>entry</var>).</li>
+          <li>If the <a data-cite="HTML/webappapis.html#current-global-object">current global object</a> is a <code>Window</code> object and <var>markName</var> uses the same name as a <a data-cite="WEBIDL#dfn-read-only">read only attribute</a> in the <code><a data-cite="NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+          <li>Create a new <a>PerformanceMark</a> object (<var>entry</var>) with the <a data-cite="ECMA-262#current-realm">current realm</a>.</li>
           <li>Set <var>entry</var>'s <code>name</code> attribute to <var>markName</var>.</li>
           <li>Set <var>entry</var>'s <code>entryType</code> attribute to <code>DOMString "mark"</code>.</li>
           <li>

--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
               <li>Otherwise, let <var>start time</var> be <code>0</code>.</li>
             </ol>
           </li>
-          <li>Create a new <a>PerformanceMeasure</a> object (<var>entry</var>) with the <a data-cite="ECMA-262#current-realm">current realm</a>.</li>
+          <li>Create a new <a>PerformanceMeasure</a> object (<var>entry</var>) with <a data-cite="WEBIDL#this">this</a>'s <a data-cite="HTML/webappapis.html#concept-relevant-realm">relevant realm</a>.</li>
           <li>Set <var>entry</var>'s <code>name</code> attribute to <var>measureName</var>.</li>
           <li>Set <var>entry</var>'s <code>entryType</code> attribute to <code>DOMString "measure"</code>.</li>
           <li>Set <var>entry</var>'s <code>startTime</code> attribute to <var>start time</var>.</li>
@@ -315,7 +315,7 @@
         <p>The <a>PerformanceMark constructor</a> must run the following steps:</p>
         <ol>
           <li>If the <a data-cite="HTML/webappapis.html#current-global-object">current global object</a> is a <code>Window</code> object and <var>markName</var> uses the same name as a <a data-cite="WEBIDL#dfn-read-only">read only attribute</a> in the <code><a data-cite="NAVIGATION-TIMING#performancetiming">PerformanceTiming</a></code> interface, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
-          <li>Create a new <a>PerformanceMark</a> object (<var>entry</var>) with the <a data-cite="ECMA-262#current-realm">current realm</a>.</li>
+          <li>Create a new <a>PerformanceMark</a> object (<var>entry</var>) with the <a data-cite="HTML/webappapis.html#current-global-object">current global object</a>'s <a data-cite="HTML/webappapis.html#concept-global-object-realm">realm</a>.</li>
           <li>Set <var>entry</var>'s <code>name</code> attribute to <var>markName</var>.</li>
           <li>Set <var>entry</var>'s <code>entryType</code> attribute to <code>DOMString "mark"</code>.</li>
           <li>


### PR DESCRIPTION
Passing the current realm works since they are only constructed on JS calls. Related issue: https://github.com/w3c/performance-timeline/issues/162


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/70.html" title="Last updated on Mar 25, 2020, 7:24 PM UTC (83eda68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/70/d72ca7e...83eda68.html" title="Last updated on Mar 25, 2020, 7:24 PM UTC (83eda68)">Diff</a>