### PR TITLE
Remove incorrect non-empty check

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         <h2><dfn>measure()</dfn> method</h2>
         <p>Stores the {{DOMHighResTimeStamp}} duration between two marks along with the associated name (a "measure"). It MUST run these steps:</p>
         <ol>
-          <li>If <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, run the following checks:
+          <li>If <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object and at least one of <a>start</a>, <a>end</a>, <a>duration</a>, and <a>detail</a> are <a data-cite="WEBIDL#dfn-present">present</a>, run the following checks:
             <ol>
               <li>If <var>endMark</var> is given, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
               <li>If <var>startOrMeasureOptions</var>'s <a>start</a> and <a>end</a> members are both omitted, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         <h2><dfn>measure()</dfn> method</h2>
         <p>Stores the {{DOMHighResTimeStamp}} duration between two marks along with the associated name (a "measure"). It MUST run these steps:</p>
         <ol>
-          <li>If <var>startOrMeasureOptions</var> is a non-<a data-cite="INFRA#map-is-empty">empty</a> <a>PerformanceMeasureOptions</a> object, run the following checks:
+          <li>If <var>startOrMeasureOptions</var> is a <a>PerformanceMeasureOptions</a> object, run the following checks:
             <ol>
               <li>If <var>endMark</var> is given, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>
               <li>If <var>startOrMeasureOptions</var>'s <a>start</a> and <a>end</a> members are both omitted, <a data-cite="WEBIDL#dfn-throw">throw</a> a <a data-cite="WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>.</li>


### PR DESCRIPTION
Fixes https://github.com/w3c/user-timing/issues/89


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/90.html" title="Last updated on Apr 26, 2022, 3:37 PM UTC (42b442a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/90/acbd329...42b442a.html" title="Last updated on Apr 26, 2022, 3:37 PM UTC (42b442a)">Diff</a>