### PR TITLE
Revert "Expose everywhere"

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
       <h2>The <dfn>PerformanceMark</dfn> Interface</h2>
       <p>The <a>PerformanceMark</a> interface also exposes marks created via the {{Performance}} interface's {{Performance/mark()}} method to the <a data-cite="PERFORMANCE-TIMELINE-2#dfn-performance-timeline">Performance Timeline</a>.</p>
       <pre class="idl">
-        [Exposed=*]
+        [Exposed=(Window,Worker)]
         interface PerformanceMark : PerformanceEntry {
           constructor(DOMString markName, optional PerformanceMarkOptions markOptions = {});
           readonly attribute any detail;
@@ -347,7 +347,7 @@
       <h2>The <dfn>PerformanceMeasure</dfn> Interface</h2>
       <p>The <a>PerformanceMeasure</a> interface also exposes measures created via the {{Performance}} interface's {{Performance/measure()}} method to the <a data-cite="PERFORMANCE-TIMELINE-2#performance-timeline">Performance Timeline</a>.</p>
       <pre class="idl">
-        [Exposed=*]
+        [Exposed=(Window,Worker)]
         interface PerformanceMeasure : PerformanceEntry {
           readonly attribute any detail;
         };


### PR DESCRIPTION
Reverts w3c/user-timing#85 given discussion on https://w3c.github.io/web-performance/meetings/2022/2022-06-23/index.html#h.1of8nktf4mlh


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/93.html" title="Last updated on Jul 22, 2022, 2:00 PM UTC (d1630cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/93/b9ff359...d1630cc.html" title="Last updated on Jul 22, 2022, 2:00 PM UTC (d1630cc)">Diff</a>