### PR TITLE
Add mark_use_counter recommended use name.

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@
           <dt><dfn class="export">framework</dfn></dt>
           <dd>If applicable, the underlying framework the feature is intended
             for, such as a JavaScript framework, content management system, or
-            ecommerce platform.</dd>
+            e-commerce platform.</dd>
         </dl>
         <div class="note">
           <p>In this example, the ImageOptimizationComponent for FancyJavaScriptFramework

--- a/index.html
+++ b/index.html
@@ -437,7 +437,15 @@
       <dt>"<dfn class="export">mark_use_counter</dfn>"</dt>
       <dd>Mark the usage of a feature which may impact performance so that
         tooling and analytics can take it into account. The <a data-link-for="PerformanceMark">detail</a>
-        metadata should contain information about which feature is used.
+        metadata can contain any useful information about the feature, including:
+        <dl>
+          <dt><dfn class="export">feature</dfn></dt>
+          <dd>The name of the feature used.</dd>
+          <dt><dfn class="export">framework</dfn></dt>
+          <dd>If applicable, the underlying framework the feature is intended
+            for, such as a JavaScript framework, content management system, or
+            ecommerce platform.</dd>
+        </dl>
         <div class="note">
           <p>In this example, the ImageOptimizationComponent for FancyJavaScriptFramework
             is used to size images for optimal performance. The code notes

--- a/index.html
+++ b/index.html
@@ -409,31 +409,52 @@
     <dl>
       <dt>"<dfn class="export">mark_fully_loaded</dfn>"</dt>
       <dd>The time when the page is considered fully loaded as marked by the
-        developer in their application.</dd>
+        developer in their application.
+        <div class="note">
+          <p>In this example, the page asynchonously initializes a chat widget, a
+            searchbox, and a newsfeed upon loading. When finished, the
+            "<a>mark_fully_loaded</a>" mark name enables lab tools and analytics
+            providers to automatically show the timing.
+          </p>
+          <pre class="example">
+                window.addEventListener("load", (event) => {
+                  Promise.all([
+                    loadChatWidget(),
+                    initializeSearchAutocomplete(),
+                    initializeNewsfeed()]).then(() => {
+                      performance.mark('mark_fully_loaded');
+                  });
+                });
+              </pre>
+        </div>
+      </dd>
       <dt>"<dfn class="export">mark_fully_visible</dfn>"</dt>
       <dd>The time when the page is considered fully visible to an end-user
         as marked by the developer in their application.</dd>
       <dt>"<dfn class="export">mark_interactive</dfn>"</dt>
       <dd>The time when the page is considered interactive to an end-user as
         marked by the developer in their application.</dd>
+      <dt>"<dfn class="export">mark_use_counter</dfn>"</dt>
+      <dd>Mark the usage of a feature which may impact performance so that
+        tooling and analytics can take it into account. The <a data-link-for="PerformanceMark">detail</a>
+        metadata should contain information about which feature is used.
+        <div class="note">
+          <p>In this example, the ImageOptimizationComponent for FancyJavaScriptFramework
+            is used to size images for optimal performance. The code notes
+            this feature's usage so that lab tools and analytics can measure
+            whether it helped improve performance.
+          </p>
+          <pre class="example">
+            performance.mark('mark_use_counter', {
+              'detail': {
+                'feature': 'ImageOptimizationComponent',
+                'framework': 'FancyJavaScriptFramework'
+              }
+            })
+          </pre>
+        </div>
+      </dd>
     </dl>
-    <div class="note">
-      <p>In this example, the page asynchonously initializes a chat widget, a
-      searchbox, and a newsfeed upon loading. When finished, the
-      "<a>mark_fully_loaded</a>" mark name enables lab tools and analytics
-      providers to automatically show the timing.
-      </p>
-      <pre class="example">
-        window.addEventListener("load", (event) => {
-          Promise.all([
-            loadChatWidget(),
-            initializeSearchAutocomplete(),
-            initializeNewsfeed()]).then(() => {
-              performance.mark('mark_fully_loaded');
-          });
-        });
-      </pre>
-    </div>
   </section>
   <section id="privacy-security" class="informative">
     <h2>Privacy and Security</h2>


### PR DESCRIPTION
Addresses #105.

Also move `mark_fully_loaded` example inline so that it's easier to relate examples to recommended mark names now that there are multiple examples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/107.html" title="Last updated on Nov 14, 2023, 1:57 PM UTC (cb96843)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/107/d59be49...cb96843.html" title="Last updated on Nov 14, 2023, 1:57 PM UTC (cb96843)">Diff</a>