### PR TITLE
Remove level

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>User Timing Level 3</title>
+  <title>User Timing</title>
   <meta charset="utf-8">
   <meta name="color-scheme" content="light dark">
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove">
@@ -11,7 +11,7 @@
     // See http://www.w3.org/respec/ for ReSpec documentation.
     var respecConfig = {
       specStatus: 'ED',
-      shortName: 'user-timing-3',
+      shortName: 'user-timing',
       editors: [{
         name: "Nicolás Peña Moreno",
         url: 'https://github.com/npm1',
@@ -76,7 +76,7 @@
     to high precision timestamps.</p>
   </section>
   <section id="sotd">
-    <p>User Timing Level 3 is intended to supersede [[USER-TIMING-2]] and includes:</p>
+    <p>This User Timing specification is intended to supersede [[USER-TIMING-2]] and includes:</p>
     <ul>
       <li>Ability to execute marks and measures across arbitrary timestamps.</li>
       <li>Support for reporting arbitrary metadata along with marks and measures.</li>


### PR DESCRIPTION
I understand that specification only has one level nowadays and the shortname for that spec should be `user-timing`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/114.html" title="Last updated on Oct 16, 2024, 12:35 PM UTC (acb615a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/114/c717421...acb615a.html" title="Last updated on Oct 16, 2024, 12:35 PM UTC (acb615a)">Diff</a>