### PR TITLE
Add 'attribute' keyword to IDL attribute dfns for Bikeshed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -293,7 +293,7 @@ interface:</p>
 
 <p>The <a>PerformanceMark</a> interface contains the following additional attribute:</p>
 
-<p>The <dfn data-dfn-for="PerformanceMark" data-export>detail</dfn> attribute must return the value it is set to (it's copied from the <a>PerformanceMarkOptions</a> dictionary).</p>
+<p>The <dfn attribute data-dfn-for="PerformanceMark" data-export>detail</dfn> attribute must return the value it is set to (it's copied from the <a>PerformanceMarkOptions</a> dictionary).</p>
 
 <h4 id="the-performancemark-constructor">The <dfn id="dom-performancemark-constructor" data-lt="PerformanceMark constructor"><a>PerformanceMark</a> Constructor</dfn></h4>
 
@@ -349,7 +349,7 @@ interface:</p>
 
 <p>The <a>PerformanceMeasure</a> interface contains the following additional attribute:</p>
 
-<p>The <dfn data-dfn-for="PerformanceMeasure" data-export>detail</dfn> attribute must return the value it is set to (it's copied from the <a>PerformanceMeasureOptions</a> dictionary).</p>
+<p>The <dfn attribute data-dfn-for="PerformanceMeasure" data-export>detail</dfn> attribute must return the value it is set to (it's copied from the <a>PerformanceMeasureOptions</a> dictionary).</p>
 
 <h2 id="processing">Processing</h2>
 


### PR DESCRIPTION
Bikeshed conversion didn't properly handle attributes. This fixes that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/pull/119.html" title="Last updated on Mar 16, 2026, 7:37 AM UTC (0de06f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/user-timing/119/9304617...0de06f1.html" title="Last updated on Mar 16, 2026, 7:37 AM UTC (0de06f1)">Diff</a>